### PR TITLE
Add frameless window with custom titlebar (#73)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ qt_add_qml_module(appgav
         BrightnessContrastPopup.qml
         PlaybackSpeedMenu.qml
         CollageButton.qml
+        TitleBar.qml
         SOURCES
         custommediaplayer.h custommediaplayer.cpp
         collage.h collage.cpp

--- a/Main.qml
+++ b/Main.qml
@@ -20,6 +20,7 @@ ApplicationWindow {
 
     // Dynamic theme switching - overrides qtquickcontrols2.conf at runtime
     Material.theme: isDarkTheme ? Material.Dark : Material.Light
+    flags: Qt.Window | Qt.FramelessWindowHint
 
     function getMediaInfo(fileUrl) {
         var path = fileUrl.toString();
@@ -112,23 +113,31 @@ ApplicationWindow {
             item.anchors.fill = mediaControlsComponentLoader
     }
 
-    // --- Loader for WINDOWED mode ---
-    menuBar: Loader {
-        id: windowedMenuBarLoader
+    TitleBar {
+        id: titleBar
 
-        active: mainWindow.visibility !== Window.FullScreen
+        readonly property bool isFullScreen: mainWindow.visibility === Window.FullScreen
 
-        // Make the Loader span the window width
         anchors.left: parent.left
         anchors.right: parent.right
+        anchors.top: parent.top
+        enabled: opacity > 0
+        height: 40
+        opacity: isFullScreen ? (controlsVisibleAlias ? 1 : 0) : 1
+        targetWindow: mainWindow
+        windowTitle: mainWindow.title
+        z: 100
 
-        // Collapse space when inactive
-        height: active && item ? item.implicitHeight : 0
-        sourceComponent: active ? menuBarComponent : null
+        Behavior on opacity {
+            NumberAnimation {
+                duration: 300
+            }
+        }
 
-        // Let the loaded MenuBar fill the Loader
-        onLoaded: if (item)
-            item.anchors.fill = windowedMenuBarLoader
+        onOpenFileRequested: fileDialog.open()
+        onExitRequested: Qt.quit()
+        onSettingsRequested: settingsDialog.open()
+        onAboutRequested: aboutDialog.open()
     }
 
     onSourceChanged: {
@@ -148,69 +157,96 @@ ApplicationWindow {
         shouldAutoPlay = true;
     }
 
-    // --- Reusable MenuBar definition ---
-    Component {
-        id: menuBarComponent
+    // Resize grips (frameless window) — only active when windowed.
+    // Edges
+    MouseArea {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        cursorShape: Qt.SizeVerCursor
+        enabled: mainWindow.visibility === Window.Windowed
+        height: 4
+        z: 102
 
-        MenuBar {
-            background: Rectangle {
-                color: Material.background.darker(1.2)
-            }
-
-            Menu {
-                title: qsTr("File")
-
-                Action {
-                    text: qsTr("Open")
-
-                    onTriggered: fileDialog.open()
-                }
-                MenuSeparator {
-                }
-                Action {
-                    text: qsTr("Exit")
-
-                    onTriggered: Qt.quit()
-                }
-            }
-            Menu {
-                title: qsTr("View")
-
-                Action {
-                    text: qsTr("Settings")
-                    onTriggered: settingsDialog.open()
-                }
-            }
-            Menu {
-                title: qsTr("Help")
-
-                Action {
-                    text: qsTr("About")
-
-                    onTriggered: aboutDialog.open()
-                }
-            }
-        }
+        onPressed: mainWindow.startSystemResize(Qt.TopEdge)
     }
-
-    // --- Loader for FULLSCREEN mode ---
-    Loader {
-        id: fullscreenMenuBarLoader
-
-        active: mainWindow.visibility === Window.FullScreen
-        enabled: opacity > 0
-        height: item ? item.implicitHeight : 0
-        opacity: !controlsVisibleAlias ? 0 : 1
-        sourceComponent: menuBarComponent
-        width: parent.width
-        y: 0
+    MouseArea {
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        cursorShape: Qt.SizeVerCursor
+        enabled: mainWindow.visibility === Window.Windowed
+        height: 4
         z: 100
 
-        Behavior on opacity {
-            NumberAnimation {
-                duration: 300
-            }
-        }
+        onPressed: mainWindow.startSystemResize(Qt.BottomEdge)
+    }
+    MouseArea {
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.top: parent.top
+        cursorShape: Qt.SizeHorCursor
+        enabled: mainWindow.visibility === Window.Windowed
+        width: 4
+        z: 100
+
+        onPressed: mainWindow.startSystemResize(Qt.LeftEdge)
+    }
+    MouseArea {
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
+        anchors.top: parent.top
+        cursorShape: Qt.SizeHorCursor
+        enabled: mainWindow.visibility === Window.Windowed
+        width: 4
+        z: 100
+
+        onPressed: mainWindow.startSystemResize(Qt.RightEdge)
+    }
+    // Corners (drawn above edges)
+    MouseArea {
+        anchors.left: parent.left
+        anchors.top: parent.top
+        cursorShape: Qt.SizeFDiagCursor
+        enabled: mainWindow.visibility === Window.Windowed
+        height: 8
+        width: 8
+        z: 101
+
+        onPressed: mainWindow.startSystemResize(Qt.LeftEdge | Qt.TopEdge)
+    }
+    MouseArea {
+        anchors.right: parent.right
+        anchors.top: parent.top
+        cursorShape: Qt.SizeBDiagCursor
+        enabled: mainWindow.visibility === Window.Windowed
+        height: 8
+        width: 8
+        z: 101
+
+        onPressed: mainWindow.startSystemResize(Qt.RightEdge | Qt.TopEdge)
+    }
+    MouseArea {
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        cursorShape: Qt.SizeBDiagCursor
+        enabled: mainWindow.visibility === Window.Windowed
+        height: 8
+        width: 8
+        z: 101
+
+        onPressed: mainWindow.startSystemResize(Qt.LeftEdge | Qt.BottomEdge)
+    }
+    MouseArea {
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
+        cursorShape: Qt.SizeFDiagCursor
+        enabled: mainWindow.visibility === Window.Windowed
+        height: 8
+        width: 8
+        z: 101
+
+        onPressed: mainWindow.startSystemResize(Qt.RightEdge | Qt.BottomEdge)
     }
     CustomSnackbar {
         id: captureSnackbar
@@ -451,7 +487,10 @@ ApplicationWindow {
     MediaComponent {
         id: mediaComponent
 
-        anchors.fill: parent
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: mainWindow.visibility === Window.FullScreen ? parent.top : titleBar.bottom
         focus: true
         path: ""
 
@@ -504,7 +543,10 @@ ApplicationWindow {
     PlayListComponent {
         id: playlistComponent
 
-        anchors.fill: parent
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: mainWindow.visibility === Window.FullScreen ? parent.top : titleBar.bottom
         collageTarget: collage
         playList: playList
         visible: !mediaComponent.isVideoAndPlaying || mainWindow.playlistManualVisible

--- a/MediaComponent.qml
+++ b/MediaComponent.qml
@@ -17,9 +17,6 @@ Item {
     signal stopped
     signal fullscreenToggleRequested
 
-    height: parent.height
-    width: parent.width
-
     CustomMediaPlayer {
         id: customMediaPlayer
 

--- a/TitleBar.qml
+++ b/TitleBar.qml
@@ -1,0 +1,278 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Controls.Material
+import QtQuick.Layouts
+
+import gavqml
+
+Rectangle {
+    id: root
+
+    required property Window targetWindow
+    property string windowTitle: ""
+
+    readonly property bool isMac: Qt.platform.os === "osx"
+    readonly property bool isMaximized: targetWindow.visibility === Window.Maximized
+
+    signal openFileRequested
+    signal exitRequested
+    signal settingsRequested
+    signal aboutRequested
+
+    function toggleMaximize() {
+        if (targetWindow.visibility === Window.Maximized) {
+            targetWindow.visibility = Window.Windowed;
+        } else {
+            targetWindow.visibility = Window.Maximized;
+        }
+    }
+
+    color: Material.background.darker(1.2)
+    implicitHeight: 32
+
+    FontLoader {
+        id: materialSymbolsOutlined
+
+        source: "qrc:/assets/fonts/MaterialSymbolsOutlined.ttf"
+    }
+
+    DragHandler {
+        target: null
+        onActiveChanged: if (active)
+            root.targetWindow.startSystemMove()
+    }
+
+    TapHandler {
+        onDoubleTapped: root.toggleMaximize()
+    }
+
+    RowLayout {
+        anchors.fill: parent
+        spacing: 8
+
+        // macOS: traffic lights on the left
+        Row {
+            Layout.alignment: Qt.AlignVCenter
+            Layout.leftMargin: 10
+            spacing: 8
+            visible: root.isMac
+
+            Rectangle {
+                color: "#ff5f57"
+                height: 12
+                radius: 6
+                width: 12
+
+                MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+
+                    onClicked: root.exitRequested()
+                }
+            }
+            Rectangle {
+                color: "#febc2e"
+                height: 12
+                radius: 6
+                width: 12
+
+                MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+
+                    onClicked: root.targetWindow.showMinimized()
+                }
+            }
+            Rectangle {
+                color: "#28c840"
+                height: 12
+                radius: 6
+                width: 12
+
+                MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+
+                    onClicked: root.toggleMaximize()
+                }
+            }
+        }
+
+        // Windows/Linux: title text on the left
+        Text {
+            Layout.alignment: Qt.AlignVCenter
+            Layout.leftMargin: 10
+            Layout.maximumWidth: 280
+            color: Material.foreground
+            elide: Text.ElideRight
+            text: root.windowTitle
+            visible: !root.isMac
+        }
+
+        // Inline menu (File / View / Help) for all platforms
+        Row {
+            Layout.alignment: Qt.AlignVCenter
+            Layout.leftMargin: 8
+
+            Button {
+                id: fileMenuButton
+
+                Material.roundedScale: Material.NotRounded
+                flat: true
+                font.pixelSize: 12
+                padding: 6
+                text: qsTr("File")
+
+                onClicked: fileMenu.open()
+
+                Menu {
+                    id: fileMenu
+
+                    y: fileMenuButton.height
+
+                    Action {
+                        text: qsTr("Open")
+
+                        onTriggered: root.openFileRequested()
+                    }
+                    MenuSeparator {
+                    }
+                    Action {
+                        text: qsTr("Exit")
+
+                        onTriggered: root.exitRequested()
+                    }
+                }
+            }
+            Button {
+                id: viewMenuButton
+
+                Material.roundedScale: Material.NotRounded
+                flat: true
+                font.pixelSize: 12
+                padding: 6
+                text: qsTr("View")
+
+                onClicked: viewMenu.open()
+
+                Menu {
+                    id: viewMenu
+
+                    y: viewMenuButton.height
+
+                    Action {
+                        text: qsTr("Settings")
+
+                        onTriggered: root.settingsRequested()
+                    }
+                }
+            }
+            Button {
+                id: helpMenuButton
+
+                Material.roundedScale: Material.NotRounded
+                flat: true
+                font.pixelSize: 12
+                padding: 6
+                text: qsTr("Help")
+
+                onClicked: helpMenu.open()
+
+                Menu {
+                    id: helpMenu
+
+                    y: helpMenuButton.height
+
+                    Action {
+                        text: qsTr("About")
+
+                        onTriggered: root.aboutRequested()
+                    }
+                }
+            }
+        }
+        Item {
+            Layout.fillWidth: true
+        }
+
+        // macOS: title on the right (after the spacer)
+        Text {
+            Layout.alignment: Qt.AlignVCenter
+            Layout.rightMargin: 10
+            color: Material.foreground
+            elide: Text.ElideRight
+            text: root.windowTitle
+            visible: root.isMac
+        }
+
+        // Windows/Linux: window buttons on the right
+        Row {
+            Layout.alignment: Qt.AlignVCenter
+            spacing: 0
+            visible: !root.isMac
+
+            ToolButton {
+                id: minimizeButton
+
+                ToolTip.delay: AppConstants.tooltipDelay
+                ToolTip.text: qsTr("Minimize")
+                ToolTip.timeout: AppConstants.tooltipTimeout
+                ToolTip.visible: hovered
+                font.family: materialSymbolsOutlined.name
+                font.pixelSize: 16
+                height: 30
+                hoverEnabled: true
+                padding: 0
+                text: "\ue15b"
+                width: 46
+
+                onClicked: root.targetWindow.showMinimized()
+            }
+            ToolButton {
+                id: maximizeButton
+
+                ToolTip.delay: AppConstants.tooltipDelay
+                ToolTip.text: root.isMaximized ? qsTr("Restore") : qsTr("Maximize")
+                ToolTip.timeout: AppConstants.tooltipTimeout
+                ToolTip.visible: hovered
+                font.family: materialSymbolsOutlined.name
+                font.pixelSize: 16
+                height: 30
+                hoverEnabled: true
+                padding: 0
+                text: root.isMaximized ? "\ue3bb" : "\ue3c6"
+                width: 46
+
+                onClicked: root.toggleMaximize()
+            }
+            ToolButton {
+                id: closeButton
+
+                ToolTip.delay: AppConstants.tooltipDelay
+                ToolTip.text: qsTr("Close")
+                ToolTip.timeout: AppConstants.tooltipTimeout
+                ToolTip.visible: hovered
+                font.family: materialSymbolsOutlined.name
+                font.pixelSize: 16
+                height: 30
+                hoverEnabled: true
+                padding: 0
+                text: "\ue5cd"
+                width: 46
+
+                onClicked: root.exitRequested()
+
+                background: Rectangle {
+                    color: closeButton.hovered ? "#e81123" : "transparent"
+                }
+                contentItem: Text {
+                    color: closeButton.hovered ? "white" : Material.foreground
+                    font: closeButton.font
+                    horizontalAlignment: Text.AlignHCenter
+                    text: closeButton.text
+                    verticalAlignment: Text.AlignVCenter
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Remove the native OS title bar in favor of an in-QML TitleBar that renders File/View/Help menus and window buttons with platform-adaptive chrome (traffic lights on macOS, min/max/close on Windows/Linux). Drag moves via startSystemMove; eight edge/corner grips resize via startSystemResize. In fullscreen the titlebar overlays the video and fades with controlsVisibleAlias, matching the media controls pattern.

closes #73 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Frameless window support with a custom, platform-aware title bar (window controls, file/view/help menus).
  * Drag-to-move, double-click-to-maximize, and integrated menu actions (Open, Exit, Settings, About).

* **Refactor**
  * Consolidated menu UI into the title bar and simplified fullscreen handling.
  * Improved windowed resizing via edge/corner grips and adjusted layout anchoring for media and playlist areas.
  * Minor media sizing behavior tweak.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->