### PR TITLE
Change name from GAV to GAV Player

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -11,6 +11,7 @@ import gavqml
 ApplicationWindow {
     id: mainWindow
 
+    readonly property string appTitle: qsTr("GAV Player")
     property bool controlsVisibleAlias: mediaComponent.controlsAreVisible
     property bool isDarkTheme: true
     property bool mediaControlsContainsMouse: false
@@ -75,7 +76,7 @@ ApplicationWindow {
     height: Screen.height * 0.75
     minimumHeight: 480
     minimumWidth: 640
-    title: qsTr("GAV")
+    title: appTitle
     visible: true
     width: Screen.width * 0.7
 
@@ -118,7 +119,7 @@ ApplicationWindow {
             return;
         playList.append(mediaInfo);
         mediaComponent.path = mediaInfo.path;
-        mainWindow.title = "GAV - " + mediaInfo.name;
+        mainWindow.title = appTitle + " - " + mediaInfo.name;
         playlistComponent.playListView.currentIndex = playList.count - 1;
         shouldAutoPlay = true;
     }
@@ -368,7 +369,7 @@ ApplicationWindow {
                 color: Material.foreground
                 font.pixelSize: 20
                 font.weight: Font.DemiBold
-                text: "GAV Media Player"
+                text: appTitle
             }
             Text {
                 Layout.alignment: Qt.AlignHCenter
@@ -687,7 +688,7 @@ ApplicationWindow {
                     font.pixelSize: 14
                     text: {
                         if (updateDialog.checkState === "available")
-                            return qsTr("A new version of GAV is available.");
+                            return qsTr("A new version of %1 is available.").arg(appTitle);
                         if (updateDialog.checkState === "upToDate")
                             return qsTr("You're on the latest version.");
                         return qsTr("Could not check for updates.");
@@ -788,7 +789,7 @@ ApplicationWindow {
                     playList.append(mediaInfo);
                     if (!firstFileSet) {
                         mediaComponent.path = mediaInfo.path;
-                        mainWindow.title = "GAV - " + mediaInfo.name;
+                        mainWindow.title = appTitle + " - " + mediaInfo.name;
                         playlistComponent.playListView.currentIndex = playList.count - 1;
                         firstFileSet = true;
                     }
@@ -808,7 +809,7 @@ ApplicationWindow {
                 return;
             playList.append(mediaInfo);
             mediaComponent.path = mediaInfo.path;
-            mainWindow.title = "GAV - " + mediaInfo.name;
+            mainWindow.title = appTitle + " - " + mediaInfo.name;
             playlistComponent.playListView.currentIndex = playList.count - 1;
         }
     }
@@ -836,7 +837,7 @@ ApplicationWindow {
         }
         onStopped: {
             mediaComponent.path = "";
-            mainWindow.title = qsTr("GAV");
+            mainWindow.title = appTitle;
         }
 
         Shortcut {
@@ -884,14 +885,14 @@ ApplicationWindow {
 
         onItemSelected: function (path, name) {
             mediaComponent.path = path;
-            mainWindow.title = "GAV - " + name;
+            mainWindow.title = appTitle + " - " + name;
             mediaComponent.mediaPlayer.play();
         }
         onPlayRequested: {
             if (mediaComponent.path === "" && playlistComponent.playListView.currentIndex !== -1) {
                 var item = playList.get(playlistComponent.playListView.currentIndex);
                 mediaComponent.path = item.path;
-                mainWindow.title = "GAV - " + item.name;
+                mainWindow.title = appTitle + " - " + item.name;
             }
             mediaComponent.mediaPlayer.play();
         }

--- a/support/cpack.cmake
+++ b/support/cpack.cmake
@@ -23,14 +23,15 @@ endif ()
 
 # CPack settings
 set(CPACK_PRE_BUILD_SCRIPTS ${QT_DEPLOY_SUPPORT})
-set(CPACK_PACKAGE_NAME "GAV")
+set(CPACK_PACKAGE_NAME "GAV Player")
+set(GAV_PACKAGE_FILENAME "GAV-Player")
 set(CPACK_PACKAGE_VENDOR "Akshay Raj Gollahalli")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "GAV - A simple audio and video player")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "GAV Player - A simple audio and video player")
 set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
 set(CPACK_PACKAGE_VERSION_MAJOR "${PROJECT_VERSION_MAJOR}")
 set(CPACK_PACKAGE_VERSION_MINOR "${PROJECT_VERSION_MINOR}")
 set(CPACK_PACKAGE_VERSION_PATCH "${PROJECT_VERSION_PATCH}")
-set(CPACK_PACKAGE_INSTALL_DIRECTORY "GAV")
+set(CPACK_PACKAGE_INSTALL_DIRECTORY "GAV Player")
 set(CPACK_PACKAGE_CONTACT "Akshay Raj Gollahalli <akshay@gollahalli.com>")
 SET(CPACK_OUTPUT_FILE_PREFIX packages)
 set(CPACK_VERBATIM_VARIABLES YES)
@@ -41,27 +42,26 @@ set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_SOURCE_DIR}/LICENSE)
 
 # NSIS settings for Windows
 if(WIN32)
-    set(CPACK_NSIS_DISPLAY_NAME "GAV - Audio Video Player")
-    set(CPACK_NSIS_PACKAGE_NAME "GAV")
+    set(CPACK_NSIS_DISPLAY_NAME "GAV Player")
+    set(CPACK_NSIS_PACKAGE_NAME "GAV Player")
     set(CPACK_NSIS_EXECUTABLES_DIRECTORY "bin")
-    set(CPACK_NSIS_MUI_EXECUTABLES "gav.exe;GAV - Audio Video Player")
-    
+
     # Create proper shortcuts and register for Start Menu search
     set(CPACK_NSIS_CREATE_ICONS_EXTRA "
-        CreateShortCut '$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\GAV.lnk' '$INSTDIR\\\\bin\\\\gav.exe' '' '$INSTDIR\\\\bin\\\\gav.exe' 0
-        CreateShortCut '$DESKTOP\\\\GAV.lnk' '$INSTDIR\\\\bin\\\\gav.exe' '' '$INSTDIR\\\\bin\\\\gav.exe' 0
+        CreateShortCut '$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\GAV Player.lnk' '$INSTDIR\\\\bin\\\\gav.exe' '' '$INSTDIR\\\\bin\\\\gav.exe' 0
+        CreateShortCut '$DESKTOP\\\\GAV Player.lnk' '$INSTDIR\\\\bin\\\\gav.exe' '' '$INSTDIR\\\\bin\\\\gav.exe' 0
         WriteRegStr HKLM 'SOFTWARE\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\App Paths\\\\gav.exe' '' '$INSTDIR\\\\bin\\\\gav.exe'
         WriteRegStr HKLM 'SOFTWARE\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\App Paths\\\\gav.exe' 'Path' '$INSTDIR\\\\bin'
-        WriteRegStr HKLM 'SOFTWARE\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Uninstall\\\\GAV' 'DisplayVersion' '${CPACK_PACKAGE_VERSION}'
-        WriteRegStr HKLM 'SOFTWARE\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Uninstall\\\\GAV' 'DisplayName' 'GAV - Audio Video Player'
-        WriteRegStr HKLM 'SOFTWARE\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Uninstall\\\\GAV' 'Publisher' '${CPACK_PACKAGE_VENDOR}'
+        WriteRegStr HKLM 'SOFTWARE\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Uninstall\\\\GAVPlayer' 'DisplayVersion' '${CPACK_PACKAGE_VERSION}'
+        WriteRegStr HKLM 'SOFTWARE\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Uninstall\\\\GAVPlayer' 'DisplayName' 'GAV Player'
+        WriteRegStr HKLM 'SOFTWARE\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Uninstall\\\\GAVPlayer' 'Publisher' '${CPACK_PACKAGE_VENDOR}'
     ")
-    
+
     set(CPACK_NSIS_DELETE_ICONS_EXTRA "
-        Delete '$SMPROGRAMS\\\\$MUI_TEMP\\\\GAV.lnk'
-        Delete '$DESKTOP\\\\GAV.lnk'
+        Delete '$SMPROGRAMS\\\\$MUI_TEMP\\\\GAV Player.lnk'
+        Delete '$DESKTOP\\\\GAV Player.lnk'
         DeleteRegKey HKLM 'SOFTWARE\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\App Paths\\\\gav.exe'
-        DeleteRegKey HKLM 'SOFTWARE\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Uninstall\\\\GAV'
+        DeleteRegKey HKLM 'SOFTWARE\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Uninstall\\\\GAVPlayer'
     ")
     set(CPACK_NSIS_MODIFY_PATH ON)
     
@@ -74,7 +74,7 @@ if(WIN32)
     set(CPACK_NSIS_MUI_HEADERIMAGE_BITMAP "${LOGO_BMP_PATH}")
     
     # License and website
-    set(CPACK_NSIS_MENU_LINKS "https://gav.gollahalli.com" "GAV Website")
+    set(CPACK_NSIS_MENU_LINKS "https://gav.gollahalli.com" "GAV Player Website")
     
     # Standard installation settings
     set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
@@ -86,18 +86,20 @@ endif()
 
 ## Installer settings
 # DEB settings
-set(CPACK_DEBIAN_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}.deb")
+set(CPACK_DEBIAN_PACKAGE_NAME "gav-player")
+set(CPACK_DEBIAN_FILE_NAME "${GAV_PACKAGE_FILENAME}-${CPACK_PACKAGE_VERSION}-${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}.deb")
 
 # RPM settings
-set(CPACK_RPM_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}.rpm")
+set(CPACK_RPM_PACKAGE_NAME "gav-player")
+set(CPACK_RPM_FILE_NAME "${GAV_PACKAGE_FILENAME}-${CPACK_PACKAGE_VERSION}-${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}.rpm")
 
 # DMG settings
-set(CPACK_DMG_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}.dmg")
+set(CPACK_DMG_FILE_NAME "${GAV_PACKAGE_FILENAME}-${CPACK_PACKAGE_VERSION}-${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}.dmg")
 
 # TGZ settings
-set(CPACK_ARCHIVE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
+set(CPACK_ARCHIVE_FILE_NAME "${GAV_PACKAGE_FILENAME}-${CPACK_PACKAGE_VERSION}-${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
 
 # Set the package file name for all generators (including NSIS and ZIP)
-set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
+set(CPACK_PACKAGE_FILE_NAME "${GAV_PACKAGE_FILENAME}-${CPACK_PACKAGE_VERSION}-${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
 
 include(CPack)

--- a/support/gav.desktop
+++ b/support/gav.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Version=1.0
-Name=GAV
+Name=GAV Player
 GenericName=Media Player
 Comment=A simple audio and video player
 Exec=gav %F


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated application branding to "GAV Player" across installers, package archives, and desktop launcher names for Windows, Linux, and macOS.
  * Updated installer and system shortcut/display names to reflect "GAV Player".

* **New Features**
  * App window and dialogs now use a single configurable app title so window titles, About text, and update messages consistently show "GAV Player".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->