### PR TITLE
Add support for appimage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,6 +52,21 @@ jobs:
         with:
           nsis-version: '3.11'
 
+      - name: Install AppImage tooling (Linux)
+        if: startsWith(matrix.os, 'ubuntu-')
+        run: |
+          set -e
+          sudo apt-get update
+          sudo apt-get install -y patchelf
+          ARCH=$(uname -m)
+          wget -q "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${ARCH}.AppImage" -O /tmp/appimagetool.AppImage
+          chmod +x /tmp/appimagetool.AppImage
+          # Extract to avoid the FUSE dependency, then expose AppRun as `appimagetool` on PATH.
+          (cd /tmp && ./appimagetool.AppImage --appimage-extract >/dev/null)
+          sudo mv /tmp/squashfs-root /opt/appimagetool
+          sudo ln -sf /opt/appimagetool/AppRun /usr/local/bin/appimagetool
+        shell: bash
+
       - name: Install Qt
         uses: akshaybabloo/actions-setup-qt@v1
         with:

--- a/support/cpack.cmake
+++ b/support/cpack.cmake
@@ -14,7 +14,11 @@ install(SCRIPT ${deploy_script})
 
 # Enable support for packing using CPack
 if(UNIX AND NOT APPLE) # Linux
-    set(CPACK_GENERATOR "TGZ;DEB;RPM")
+    set(CPACK_GENERATOR "TGZ;DEB;RPM;AppImage")
+    # The AppImage generator requires an icon whose basename (without extension) matches the .desktop Icon entry.
+    # gav.desktop uses `Icon=gav`, so stage a copy of the source PNG as `gav.png` for CPACK_PACKAGE_ICON to point at.
+    configure_file("${CMAKE_SOURCE_DIR}/assets/images/icon.png" "${CMAKE_BINARY_DIR}/gav.png" COPYONLY)
+    set(CPACK_PACKAGE_ICON "${CMAKE_BINARY_DIR}/gav.png")
 elseif(APPLE) # macOS
     set(CPACK_GENERATOR "TGZ;DragNDrop")
 elseif (WIN32)

--- a/support/cpack.cmake
+++ b/support/cpack.cmake
@@ -15,10 +15,10 @@ install(SCRIPT ${deploy_script})
 # Enable support for packing using CPack
 if(UNIX AND NOT APPLE) # Linux
     set(CPACK_GENERATOR "TGZ;DEB;RPM;AppImage")
-    # The AppImage generator requires an icon whose basename (without extension) matches the .desktop Icon entry.
-    # gav.desktop uses `Icon=gav`, so stage a copy of the source PNG as `gav.png` for CPACK_PACKAGE_ICON to point at.
-    configure_file("${CMAKE_SOURCE_DIR}/assets/images/icon.png" "${CMAKE_BINARY_DIR}/gav.png" COPYONLY)
-    set(CPACK_PACKAGE_ICON "${CMAKE_BINARY_DIR}/gav.png")
+    # The AppImage generator expects CPACK_PACKAGE_ICON to be a bare filename that StringStartsWith the desktop file's
+    # `Icon=` value; it then locates the file in the staged install tree via FindFile. gav.desktop has `Icon=gav`, and
+    # the install rule places the PNG at share/icons/hicolor/256x256/apps/gav.png.
+    set(CPACK_PACKAGE_ICON "gav.png")
 elseif(APPLE) # macOS
     set(CPACK_GENERATOR "TGZ;DragNDrop")
 elseif (WIN32)


### PR DESCRIPTION
closes #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added AppImage as a Linux distribution format.
  * Enhanced package configuration to include an application icon for AppImage.
  * CI updated to install and prepare AppImage tooling on Ubuntu runners to enable AppImage packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->