### PR TITLE
Use proper restore icon

### DIFF
--- a/TitleBar.qml
+++ b/TitleBar.qml
@@ -258,7 +258,7 @@ Rectangle {
                 height: windowButtons.buttonHeight
                 hoverEnabled: true
                 padding: 0
-                text: root.isMaximized ? "\ue3bb" : "\ue3c6"
+                text: root.isMaximized ? "\ue3e0" : "\ue3c6"
                 width: windowButtons.buttonWidth
 
                 background: Rectangle {


### PR DESCRIPTION
closes #138 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the window maximize/restore button icon so it now shows the correct symbol when the window is maximized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->