### PR TITLE
Center window title

### DIFF
--- a/TitleBar.qml
+++ b/TitleBar.qml
@@ -46,6 +46,18 @@ Rectangle {
     TapHandler {
         onDoubleTapped: root.toggleMaximize()
     }
+
+    // Window title
+    Text {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.verticalCenter: parent.verticalCenter
+        color: Material.foreground
+        elide: Text.ElideRight
+        horizontalAlignment: Text.AlignHCenter
+        text: root.windowTitle
+        width: Math.min(implicitWidth, parent.width - 200)
+    }
+
     RowLayout {
         anchors.fill: parent
         spacing: 8
@@ -96,17 +108,6 @@ Rectangle {
                     onClicked: root.toggleMaximize()
                 }
             }
-        }
-
-        // Windows/Linux: title text on the left
-        Text {
-            Layout.alignment: Qt.AlignVCenter
-            Layout.leftMargin: 10
-            Layout.maximumWidth: 280
-            color: Material.foreground
-            elide: Text.ElideRight
-            text: root.windowTitle
-            visible: !root.isMac
         }
 
         // Inline menu (File / View / Help) for all platforms
@@ -198,16 +199,6 @@ Rectangle {
         }
         Item {
             Layout.fillWidth: true
-        }
-
-        // macOS: title on the right (after the spacer)
-        Text {
-            Layout.alignment: Qt.AlignVCenter
-            Layout.rightMargin: 10
-            color: Material.foreground
-            elide: Text.ElideRight
-            text: root.windowTitle
-            visible: root.isMac
         }
 
         // Windows/Linux: window buttons on the right


### PR DESCRIPTION
closes #141 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the window header to show a single centered title for a cleaner, more consistent look.
  * Improved title sizing so it stays within the available header space.
  * Removed platform-specific title placements, making the header display uniform across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->