### PR TITLE
Fix builds

### DIFF
--- a/support/cpack.cmake
+++ b/support/cpack.cmake
@@ -15,32 +15,16 @@ install(SCRIPT ${deploy_script})
 # When GAV_QTMULTIMEDIA_PLUGIN is provided, replace Qt's bundled ffmpegmediaplugin in the install tree with a custom
 # build (statically linked against vcpkg's newer FFmpeg). Runs AFTER the Qt deploy script so we override its output.
 if(GAV_QTMULTIMEDIA_PLUGIN)
-    # Normalize to forward slashes so the path embeds safely into cmake_install.cmake. On Windows GITHUB_WORKSPACE
-    # comes through as D:\a\gav\gav — CMake's string parser then reads `\a` etc. as escape sequences and fails.
     file(TO_CMAKE_PATH "${GAV_QTMULTIMEDIA_PLUGIN}" _gav_qtmm_plugin)
     if(NOT EXISTS "${_gav_qtmm_plugin}")
         message(FATAL_ERROR "GAV_QTMULTIMEDIA_PLUGIN points to non-existent file: ${_gav_qtmm_plugin}")
     endif()
-    install(CODE "
-        file(GLOB_RECURSE _existing_plugin LIST_DIRECTORIES false
-            \"\${CMAKE_INSTALL_PREFIX}/*ffmpegmediaplugin*\")
-        list(FILTER _existing_plugin EXCLUDE REGEX \"\\\\.(dSYM|pdb|debug)$\")
-        if(_existing_plugin)
-            list(GET _existing_plugin 0 _existing_plugin)
-            get_filename_component(_dest_dir \"\${_existing_plugin}\" DIRECTORY)
-            get_filename_component(_existing_name \"\${_existing_plugin}\" NAME)
-            message(STATUS \"GAV: replacing bundled FFmpeg plugin at \${_existing_plugin}\")
-            file(REMOVE \"\${_existing_plugin}\")
-            file(COPY \"${_gav_qtmm_plugin}\" DESTINATION \"\${_dest_dir}\")
-            # Rename if the source basename differs from what Qt deployed (e.g. shared- vs static-build naming).
-            get_filename_component(_new_name \"${_gav_qtmm_plugin}\" NAME)
-            if(NOT _new_name STREQUAL _existing_name)
-                file(RENAME \"\${_dest_dir}/\${_new_name}\" \"\${_dest_dir}/\${_existing_name}\")
-            endif()
-        else()
-            message(FATAL_ERROR \"GAV_QTMULTIMEDIA_PLUGIN set but no ffmpegmediaplugin found in install tree to override\")
-        endif()
-    ")
+    if(APPLE)
+        set(_gav_qtmm_dest "gav.app/Contents/PlugIns/multimedia")
+    else()
+        set(_gav_qtmm_dest "plugins/multimedia")
+    endif()
+    install(FILES "${_gav_qtmm_plugin}" DESTINATION "${_gav_qtmm_dest}")
 endif()
 
 # Enable support for packing using CPack


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved packaging of the multimedia plugin by validating the provided plugin file and installing it directly into the correct Qt plugin subdirectory.
  * Ensures the plugin is placed properly on macOS (inside the app bundle) and on other platforms, making packaging more consistent and reducing installation-related failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->